### PR TITLE
Ansible smart_mgmt provisioner - Switch use of {% raw %} ... {% endraw %} in Jinja2 to !unsafe

### DIFF
--- a/provisioner/workshop_specific/smart_mgmt.yml
+++ b/provisioner/workshop_specific/smart_mgmt.yml
@@ -70,9 +70,9 @@
             - host
         injectors:
           env:
-            FOREMAN_SERVER: "{% raw %}{{ '{{host}}' }}{% endraw %}"
-            FOREMAN_USER: "{% raw %}{{ '{{username}}' }}{% endraw %}"
-            FOREMAN_PASSWORD: "{% raw %}{{ '{{password}}' }}{% endraw %}"
+            FOREMAN_SERVER: !unsafe '{{host}}'
+            FOREMAN_USER: !unsafe '{{username}}'
+            FOREMAN_PASSWORD: !unsafe '{{password}}'
             FOREMAN_VALIDATE_CERTS: 'false'
       - name: GitHub_Personal_Access_Token
         description: Credential for GitHub repo operations automation
@@ -89,7 +89,7 @@
             - personal_access_token
         injectors:
           env:
-            MY_PA_TOKEN: "{% raw %}{{ '{{ personal_access_token }}' }}{% endraw %}"
+            MY_PA_TOKEN: !unsafe '{{ personal_access_token }}'
     controller_credentials:
       - name: Satellite Credential
         credential_type: Satellite_Collection


### PR DESCRIPTION
##### SUMMARY
A portion of `provisioner/workshop_specific/smart_mgmt.yml` configures controller_credential_types and utilizes {% raw %} ... {% endraw %} Jinja2 templating for variable name injection. Switching to `!unsafe` is more comprehensive than escaping Jinja2 with {% raw %} ... {% endraw %} tags.
From: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner
