### PR TITLE
Fixes for CISCO AMI and size for AAP2 Network CI

### DIFF
--- a/roles/manage_ec2_instances/defaults/main/main.yml
+++ b/roles/manage_ec2_instances/defaults/main/main.yml
@@ -60,7 +60,7 @@ ec2_info:
           volume_type: gp3
           iops: 1000
           throughput: 125
-          volume_size: 8
+          volume_size: 16
           delete_on_termination: true
   arista:
     size: c5.xlarge

--- a/roles/manage_ec2_instances/tasks/ami_find/ami_find_network.yml
+++ b/roles/manage_ec2_instances/tasks/ami_find/ami_find_network.yml
@@ -7,7 +7,7 @@
         region: "{{ ec2_region }}"
         owners: "679593333241"
         filters:
-          name: "cisco_CSR-17.03.06-BYOL-624f5bb1*"
+          name: "Cisco-C8K-17.*"
           architecture: "x86_64"
       register: cisco_ami_list
 


### PR DESCRIPTION
Increase volume size from 8gb to 16gb for cisco